### PR TITLE
add support for `version` record attribute

### DIFF
--- a/lib/ex_aws/timestream/write.ex
+++ b/lib/ex_aws/timestream/write.ex
@@ -309,6 +309,8 @@ defmodule ExAws.Timestream.Write do
         |> camelize_keys(deep: false)
       end)
     end)
+    |> Enum.filter(fn {_k, v} -> not is_nil(v) end)
+    |> Map.new()
     |> camelize_keys(deep: false)
   end
 

--- a/lib/ex_aws/timestream/write/record.ex
+++ b/lib/ex_aws/timestream/write/record.ex
@@ -11,7 +11,8 @@ defmodule ExAws.Timestream.Write.Record do
             measure_value: nil,
             measure_value_type: nil,
             time: nil,
-            time_unit: nil
+            time_unit: nil,
+            version: nil
 
   @type record :: %ExAws.Timestream.Write.Record{}
   @type dimension :: %ExAws.Timestream.Write.Dimension{}

--- a/test/ex_aws/timestream_test.exs
+++ b/test/ex_aws/timestream_test.exs
@@ -246,7 +246,8 @@ defmodule ExAws.TimestreamTest do
           measure_value: "measure_value",
           measure_value_type: "measure_value_type",
           time: "time",
-          time_unit: "time_unit"
+          time_unit: "time_unit",
+          version: "version"
         )
         |> Record.add_dimension(Dimension.new("fake_name", "fake_value")),
         Record.new()
@@ -274,7 +275,8 @@ defmodule ExAws.TimestreamTest do
                    "MeasureValue" => "measure_value",
                    "MeasureValueType" => "measure_value_type",
                    "Time" => "time",
-                   "TimeUnit" => "time_unit"
+                   "TimeUnit" => "time_unit",
+                   "Version" => "version"
                  },
                  %{
                    "Dimensions" => [
@@ -288,12 +290,7 @@ defmodule ExAws.TimestreamTest do
                        "Name" => "fake_name",
                        "Value" => "fake_value"
                      }
-                   ],
-                   "MeasureName" => nil,
-                   "MeasureValue" => nil,
-                   "MeasureValueType" => nil,
-                   "Time" => nil,
-                   "TimeUnit" => nil
+                   ]
                  }
                ],
                "TableName" => "table_name"
@@ -336,12 +333,7 @@ defmodule ExAws.TimestreamTest do
                      "Name" => "fake_name",
                      "Value" => "fake_value"
                    }
-                 ],
-                 "MeasureName" => nil,
-                 "MeasureValue" => nil,
-                 "MeasureValueType" => nil,
-                 "Time" => nil,
-                 "TimeUnit" => nil
+                 ]
                },
                "DatabaseName" => "database_name",
                "Records" => [
@@ -371,12 +363,7 @@ defmodule ExAws.TimestreamTest do
                        "Name" => "fake_name",
                        "Value" => "fake_value"
                      }
-                   ],
-                   "MeasureName" => nil,
-                   "MeasureValue" => nil,
-                   "MeasureValueType" => nil,
-                   "Time" => nil,
-                   "TimeUnit" => nil
+                   ]
                  }
                ],
                "TableName" => "table_name"


### PR DESCRIPTION
Add version argument (https://docs.aws.amazon.com/timestream/latest/developerguide/API_Record.html#timestream-Type-Record-Version)