### PR TITLE
Adds support for 'MULTI' MeasureValues

### DIFF
--- a/lib/ex_aws/timestream/write.ex
+++ b/lib/ex_aws/timestream/write.ex
@@ -129,7 +129,7 @@ defmodule ExAws.Timestream.Write do
 
       ExAws.Timestream.Write.create_table("database_name", "table_name")
 
-  ## Examples - create_table/3 
+  ## Examples - create_table/3
 
       tag = ExAws.Timestream.Write.Tag.new("tag_key", "tag_value")
       retention_properties = %{ magnetic_retention: 1, memory_retention: 1 }
@@ -308,6 +308,18 @@ defmodule ExAws.Timestream.Write do
         |> Map.from_struct()
         |> camelize_keys(deep: false)
       end)
+    end)
+    |> Map.update!(:measure_values, fn current_measure_value ->
+      if current_measure_value == nil or current_measure_value == [] do
+        nil
+      else
+        current_measure_value
+        |> Enum.map(fn measure_value ->
+          measure_value
+          |> Map.from_struct()
+          |> camelize_keys(deep: false)
+        end)
+      end
     end)
     |> Enum.filter(fn {_k, v} -> not is_nil(v) end)
     |> Map.new()

--- a/lib/ex_aws/timestream/write/measure_value.ex
+++ b/lib/ex_aws/timestream/write/measure_value.ex
@@ -1,0 +1,18 @@
+defmodule ExAws.Timestream.Write.MeasureValue do
+  alias __MODULE__
+
+  @moduledoc """
+  Measure Value for the time-series data point.
+  https://docs.aws.amazon.com/timestream/latest/developerguide/API_MeasureValue.html
+  """
+
+  defstruct name: [],
+            value: nil,
+            type: nil
+
+  @type measure_value :: %MeasureValue{}
+
+  @doc "Create a new MeasureValue struct"
+  @spec new(name :: binary, value :: binary, type :: binary) :: measure_value()
+  def new(name, value, type), do: %MeasureValue{name: name, value: value, type: type}
+end

--- a/lib/ex_aws/timestream/write/record.ex
+++ b/lib/ex_aws/timestream/write/record.ex
@@ -9,6 +9,7 @@ defmodule ExAws.Timestream.Write.Record do
   defstruct dimensions: [],
             measure_name: nil,
             measure_value: nil,
+            measure_values: nil,
             measure_value_type: nil,
             time: nil,
             time_unit: nil,
@@ -16,12 +17,14 @@ defmodule ExAws.Timestream.Write.Record do
 
   @type record :: %ExAws.Timestream.Write.Record{}
   @type dimension :: %ExAws.Timestream.Write.Dimension{}
+  @type measure_value :: %ExAws.Timestream.Write.MeasureValue{}
 
   @doc "Create a new Record struct"
   @type new_opts :: %{
           dimensions: [dimension],
           measure_name: binary,
           measure_value: binary,
+          measure_values: [measure_value],
           measure_value_type: binary,
           time: binary,
           time_unit: binary

--- a/test/ex_aws/timestream_test.exs
+++ b/test/ex_aws/timestream_test.exs
@@ -9,7 +9,8 @@ defmodule ExAws.TimestreamTest do
   alias ExAws.Timestream.Write.{
     Dimension,
     Record,
-    Tag
+    Tag,
+    MeasureValue
   }
 
   describe "Amazon Timestream Write actions" do
@@ -244,6 +245,7 @@ defmodule ExAws.TimestreamTest do
         Record.new(
           measure_name: "measure_name",
           measure_value: "measure_value",
+          measure_values: [],
           measure_value_type: "measure_value_type",
           time: "time",
           time_unit: "time_unit",
@@ -302,6 +304,10 @@ defmodule ExAws.TimestreamTest do
         Record.new(
           measure_name: "measure_name",
           measure_value: "measure_value",
+          measure_values: [
+            MeasureValue.new("fake_mv_name", "fake_mv_value", "fake_mv_type"),
+            MeasureValue.new("fake_mv_name_2", "fake_mv_value_2", "fake_mv_type_2")
+          ],
           measure_value_type: "measure_value_type",
           time: "time",
           time_unit: "time_unit"
@@ -347,6 +353,18 @@ defmodule ExAws.TimestreamTest do
                    ],
                    "MeasureName" => "measure_name",
                    "MeasureValue" => "measure_value",
+                   "MeasureValues" => [
+                     %{
+                       "Name" => "fake_mv_name",
+                       "Value" => "fake_mv_value",
+                       "Type" => "fake_mv_type"
+                     },
+                     %{
+                       "Name" => "fake_mv_name_2",
+                       "Value" => "fake_mv_value_2",
+                       "Type" => "fake_mv_type_2"
+                     }
+                   ],
                    "MeasureValueType" => "measure_value_type",
                    "Time" => "time",
                    "TimeUnit" => "time_unit"


### PR DESCRIPTION
Added support for `MULTI` MeasureValues - https://docs.aws.amazon.com/timestream/latest/developerguide/API_Record.html#timestream-Type-Record-MeasureValues